### PR TITLE
ネットワークエラーの場合は定期処理をスキップする

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -28,8 +28,21 @@ chrome.runtime.onInstalled.addListener(() => {
     chrome.alarms.create('alerm', { periodInMinutes: 5 });
 });
 
-chrome.alarms.onAlarm.addListener(function() {
+chrome.alarms.onAlarm.addListener(async () => {
     if (!KTR.credential.valid()) {
+        return
+    }
+
+    // 接続できない場合は何もしない
+    const connectable = await fetch(KTR.service.url(), {
+        method: 'GET',
+        cache: 'no-store',
+        credentials: 'include'
+    })
+        .then(() => true)
+        .catch(() => false);
+
+    if (!connectable) {
         return
     }
 


### PR DESCRIPTION
ネットワークが接続できない場合に5分毎にネットワークエラーがアラートででてしまうため、接続できない場合は5分毎の定期処理をスキップするようにしました。