### PR TITLE
ログイン後の勤之助の画面からデータを取得できるようにします

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -88,8 +88,8 @@ button.confirm {
 button.confirm:last-child {
   margin-left: 10px;
 }
-.time-table { width: 100%; }
-.time-table th, .time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
+#time-table { width: 100%; display: none; }
+#time-table th, #time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
 
 </style>
 <script src="/vendor/jquery.js"></script>
@@ -106,8 +106,7 @@ button.confirm:last-child {
   <li id="service" class="enabled">勤之助を開く</li>
   <li id="options" class="enabled">オプション</li>
 </ul>
-<div id="diff">
-  <table class="time-table">
+  <table id="time-table">
     <tr><th colspan="3" style="text-align: center;">勤務情報</th></tr>
     <tr>
       <th width="20%"></th>
@@ -149,7 +148,6 @@ button.confirm:last-child {
     </tr>
     <tr><td colspan="3"><small>※ 休憩時間を含む</small></td></tr>
   </table>
-</div>
 <div id="modalDialogContainer"></div>
 </body>
 </html>

--- a/html/popup.html
+++ b/html/popup.html
@@ -88,6 +88,9 @@ button.confirm {
 button.confirm:last-child {
   margin-left: 10px;
 }
+.time-table { width: 100%; }
+.time-table th, .time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
+
 </style>
 <script src="/vendor/jquery.js"></script>
 <script src="/vendor/crypto-js.js"></script>
@@ -103,6 +106,50 @@ button.confirm:last-child {
   <li id="service" class="enabled">勤之助を開く</li>
   <li id="options" class="enabled">オプション</li>
 </ul>
+<div id="diff">
+  <table class="time-table">
+    <tr><th colspan="3" style="text-align: center;">勤務情報</th></tr>
+    <tr>
+      <th width="20%"></th>
+      <th width="40%">勤務日数</th>
+      <th width="40%">勤務時間</th>
+    </tr>
+    <tr>
+      <th>所定</th>
+      <td id="fixed-day">-</td>
+      <td id="fixed-time">--:--</td>
+    </tr>
+    <tr>
+      <th>現在</th>
+      <td id="actual-day">-</td>
+      <td id="actual-time">--:--</td>
+    </tr>
+    <tr>
+      <th>休暇</th>
+      <td id="holiday">-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <th>必要</th>
+      <td id="need-day">-</td>
+      <td id="need-time">--:--</td>
+    </tr>
+    <tr>
+      <th colspan="2">予定過不足時間 <small>※</small></th>
+      <td id="expect-time">--:--</td>
+    </tr>
+    <tr><td colspan="3"><small>※ 所定時間働いた場合の過不足</small></td></tr>
+    <tr>
+      <th colspan="2">一日あたり必要時間</th>
+      <td id="time-per-day">--:--</td>
+    </tr>
+    <tr>
+      <th colspan="2">今日の勤務時間 <small>※</small></th>
+      <td id="today-time">--:--</td>
+    </tr>
+    <tr><td colspan="3"><small>※ 休憩時間を含む</small></td></tr>
+  </table>
+</div>
 <div id="modalDialogContainer"></div>
 </body>
 </html>

--- a/html/popup.html
+++ b/html/popup.html
@@ -104,9 +104,8 @@ button.confirm:last-child {
 </div>
 <ul>
   <li id="service" class="enabled">勤之助を開く</li>
-  <li id="options" class="enabled">オプション</li>
 </ul>
-  <table id="time-table">
+<table id="time-table">
     <tr><th colspan="3" style="text-align: center;">勤務情報</th></tr>
     <tr>
       <th width="20%"></th>
@@ -148,6 +147,9 @@ button.confirm:last-child {
     </tr>
     <tr><td colspan="3"><small>※ 休憩時間を含む</small></td></tr>
   </table>
+<ul>
+  <li id="options" class="enabled">オプション</li>
+</ul>
 <div id="modalDialogContainer"></div>
 </body>
 </html>

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -533,7 +533,7 @@
         get(cb) {
             KTR.service._request({
                 method: 'GET'
-            }, cb);
+            }, '', cb);
         },
 
         // POSTリクエストを送信する
@@ -544,11 +544,11 @@
                     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
                 },
                 body: Object.keys(obj).map((key) => `${key}=${encodeURIComponent(obj[key])}`).join('&')
-            }, cb);
+            }, '', cb);
         },
 
-        _request(init, cb) {
-            fetch(KTR.service.url(), Object.assign({
+        _request(init, queryString, cb) {
+            fetch(KTR.service.url() + queryString, Object.assign({
                 cache: 'no-store',
                 credentials: 'include'
             }, init))

--- a/js/popup.js
+++ b/js/popup.js
@@ -39,6 +39,14 @@ function init() {
      */
     if (KTR.credential.valid()) {
         document.querySelector('#time-table').style.display = 'block';
+        // TODO: @tosite0345 リファクタリング
+        KTR.service._request(
+            {method: 'GET'},
+            '?module=timesheet&action=browse',
+            (html) => {
+                console.log(html);
+            }
+        );
     }
 }
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -33,6 +33,13 @@ function init() {
             $service.text('新しいお知らせ').addClass('attention');
         }
     });
+
+    /**
+     * ログインしていたら勤務テーブルを表示する
+     */
+    if (KTR.credential.valid()) {
+        document.querySelector('#time-table').style.display = 'block';
+    }
 }
 
 /**


### PR DESCRIPTION
## 何を解決するのか😊

先に https://github.com/irok/KinnosukeTimeRecorder/pull/11 をマージします。
このPRでは既存の `KTR.service._request` メソッドに手を入れ、クエリストリングを指定できるようにしました。
なお、引数の都合上、 `KTR.service._request` が呼び出されている部分にも手を入れています。

### 作業範囲
- 既存メソッド修正

### TODOリスト
**１．設定が煩雑な点を何とかする**
- [ ] 共通の項目を列名から自動的に特定する
- [ ] 特定できない場合に案内を表示する
- [ ] 出勤簿のテーブルの休暇見出し行を取得する
- [ ] チェックボックスを置いて選択できるようにする

**２．認証情報がない状態を考慮する**
- [x] 未ログイン時、出勤状況テーブルを非表示にする
- [ ] 未ログイン時、出勤状況テーブル設定情報を非表示にする

**３．各メニューと出勤状況の位置を変更する**
- [x] テーブルをメニューの下部に持っていく

### スクリーンショット
![image](https://user-images.githubusercontent.com/24952964/53344578-56ef3a00-3956-11e9-8b7b-82f16639b824.png)
