### PR TITLE
空のオプション選択画面を用意します

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -70,6 +70,7 @@ button {
   font: inherit;
   text-shadow: 0 1px 0 rgb(240, 240, 240);
 }
+#after-logged-in { display: none; }
 </style>
 <script src="/vendor/jquery.js"></script>
 <script src="/vendor/crypto-js.js"></script>
@@ -110,6 +111,21 @@ button {
       <tr><td>出社時</td><td><input type="time" id="start-alarm-begin"/> - <input type="time" id="start-alarm-end"/></td></tr>
       <tr><td>退社時</td><td><input type="time" id="leave-alarm-begin"/> - <input type="time" id="leave-alarm-end"/></td></tr>
     </table>
+  </div>
+  <div id="after-logged-in">
+    <h2>勤務状況</h2>
+    <div class="settings">
+      <label><input type="radio" name="table-enable">勤務状況機能を利用する</label>
+      <label><input type="radio" name="table-enable">勤務状況機能を利用しない</label>
+    </div>
+    <h2>勤務形態</h2>
+    <div class="settings">
+      <label><input type="radio" name="work-type">固定時間制</label>
+      <label><input type="radio" name="work-type">フレックス制</label>
+    </div>
+    <h2>休暇情報</h2>
+    <div id="holiday-check" class="settings"></div>
+    <p>休日に該当するチェックボックスにチェックを入れてください。</p>
   </div>
   <button id="saveBtn">保存する</button>
 </section>

--- a/html/options.html
+++ b/html/options.html
@@ -115,13 +115,13 @@ button {
   <div id="after-logged-in">
     <h2>勤務状況</h2>
     <div class="settings">
-      <label><input type="radio" name="table-enable">勤務状況機能を利用する</label>
-      <label><input type="radio" name="table-enable">勤務状況機能を利用しない</label>
+      <label><input type="radio" name="table-enable" value="enale">勤務状況機能を利用する</label>
+      <label><input type="radio" name="table-enable" value="disable">勤務状況機能を利用しない</label>
     </div>
     <h2>勤務形態</h2>
     <div class="settings">
-      <label><input type="radio" name="work-type">固定時間制</label>
-      <label><input type="radio" name="work-type">フレックス制</label>
+      <label><input type="radio" name="work-type" value="fix">固定時間制</label>
+      <label><input type="radio" name="work-type" value="flex">フレックス制</label>
     </div>
     <h2>休暇情報</h2>
     <div id="holiday-check" class="settings"></div>

--- a/html/popup.html
+++ b/html/popup.html
@@ -88,8 +88,8 @@ button.confirm {
 button.confirm:last-child {
   margin-left: 10px;
 }
-.time-table { width: 100%; }
-.time-table th, .time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
+#time-table { width: 100%; display: none; }
+#time-table th, #time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
 
 </style>
 <script src="/vendor/jquery.js"></script>
@@ -106,8 +106,7 @@ button.confirm:last-child {
   <li id="service" class="enabled">勤之助を開く</li>
   <li id="options" class="enabled">オプション</li>
 </ul>
-<div id="diff">
-  <table class="time-table">
+  <table id="time-table">
     <tr><th colspan="3" style="text-align: center;">勤務情報</th></tr>
     <tr>
       <th width="20%"></th>
@@ -149,7 +148,6 @@ button.confirm:last-child {
     </tr>
     <tr><td colspan="3"><small>※ 休憩時間を含む</small></td></tr>
   </table>
-</div>
 <div id="modalDialogContainer"></div>
 </body>
 </html>

--- a/html/popup.html
+++ b/html/popup.html
@@ -88,6 +88,9 @@ button.confirm {
 button.confirm:last-child {
   margin-left: 10px;
 }
+.time-table { width: 100%; }
+.time-table th, .time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
+
 </style>
 <script src="/vendor/jquery.js"></script>
 <script src="/vendor/crypto-js.js"></script>
@@ -103,6 +106,50 @@ button.confirm:last-child {
   <li id="service" class="enabled">勤之助を開く</li>
   <li id="options" class="enabled">オプション</li>
 </ul>
+<div id="diff">
+  <table class="time-table">
+    <tr><th colspan="3" style="text-align: center;">勤務情報</th></tr>
+    <tr>
+      <th width="20%"></th>
+      <th width="40%">勤務日数</th>
+      <th width="40%">勤務時間</th>
+    </tr>
+    <tr>
+      <th>所定</th>
+      <td id="fixed-day">-</td>
+      <td id="fixed-time">--:--</td>
+    </tr>
+    <tr>
+      <th>現在</th>
+      <td id="actual-day">-</td>
+      <td id="actual-time">--:--</td>
+    </tr>
+    <tr>
+      <th>休暇</th>
+      <td id="holiday">-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <th>必要</th>
+      <td id="need-day">-</td>
+      <td id="need-time">--:--</td>
+    </tr>
+    <tr>
+      <th colspan="2">予定過不足時間 <small>※</small></th>
+      <td id="expect-time">--:--</td>
+    </tr>
+    <tr><td colspan="3"><small>※ 所定時間働いた場合の過不足</small></td></tr>
+    <tr>
+      <th colspan="2">一日あたり必要時間</th>
+      <td id="time-per-day">--:--</td>
+    </tr>
+    <tr>
+      <th colspan="2">今日の勤務時間 <small>※</small></th>
+      <td id="today-time">--:--</td>
+    </tr>
+    <tr><td colspan="3"><small>※ 休憩時間を含む</small></td></tr>
+  </table>
+</div>
 <div id="modalDialogContainer"></div>
 </body>
 </html>

--- a/html/popup.html
+++ b/html/popup.html
@@ -104,9 +104,8 @@ button.confirm:last-child {
 </div>
 <ul>
   <li id="service" class="enabled">勤之助を開く</li>
-  <li id="options" class="enabled">オプション</li>
 </ul>
-  <table id="time-table">
+<table id="time-table">
     <tr><th colspan="3" style="text-align: center;">勤務情報</th></tr>
     <tr>
       <th width="20%"></th>
@@ -148,6 +147,9 @@ button.confirm:last-child {
     </tr>
     <tr><td colspan="3"><small>※ 休憩時間を含む</small></td></tr>
   </table>
+<ul>
+  <li id="options" class="enabled">オプション</li>
+</ul>
 <div id="modalDialogContainer"></div>
 </body>
 </html>

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -533,7 +533,7 @@
         get(cb) {
             KTR.service._request({
                 method: 'GET'
-            }, cb);
+            }, '', cb);
         },
 
         // POSTリクエストを送信する
@@ -544,11 +544,11 @@
                     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
                 },
                 body: Object.keys(obj).map((key) => `${key}=${encodeURIComponent(obj[key])}`).join('&')
-            }, cb);
+            }, '', cb);
         },
 
-        _request(init, cb) {
-            fetch(KTR.service.url(), Object.assign({
+        _request(init, queryString, cb) {
+            fetch(KTR.service.url() + queryString, Object.assign({
                 cache: 'no-store',
                 credentials: 'include'
             }, init))

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -566,6 +566,41 @@
      * 勤務時間の詳細を取得
      */
     KTR.workInfo = {
+        fetchWorkingInfoFromHtml(html){
+            const parser  = new DOMParser();
+            const doc     = parser.parseFromString(html, 'text/html');
+            const table   = doc.querySelector(/* Working info summary table = */ 'table#total_list0 tr:nth-child(2)');
+
+            const summaryCols  = KTR.workInfo.workTableColumns(html, '<b>所定労働<br/>日数</b>');
+            const calendarCols = KTR.workInfo.workTableColumns(html, '<b>日</b>');
+
+            // 日数
+            const fixedDay = Number(table.querySelector(`td:nth-child(${summaryCols['所定労働日数']})`).textContent);
+            const workDay  = Number(table.querySelector(`td:nth-child(${summaryCols['出勤日数']})`).textContent);
+
+            // 時間
+            const fixedTimes  = table.querySelector(`td:nth-child(${summaryCols['所定労働時間']})`).textContent.split(':').map(Number);
+            const actualTimes = table.querySelector(`td:nth-child(${summaryCols['実働時間']})`).textContent.split(':').map(Number);
+
+            // 今日の勤務開始時間
+            var now    = new Date();
+            var tr     = doc.querySelector(`#fix_0_${now.getDate()}`);
+            var start  = tr.querySelector(`td:nth-child(${calendarCols['出社']})`).textContent.split(':').map(Number);
+            var actual = tr.querySelector(`td:nth-child(${calendarCols['実働時間']})`).textContent.split(':').map(Number);
+
+            // 時間が取得できていなければ00:00をセットする
+            start      = (start.length != 2)  ? [0, 0] : start;
+            actual     = (actual.length != 2) ? [0, 0] : actual;
+
+            return {
+                fixedDay:         fixedDay,
+                workDay:          workDay,
+                fixedTimes:       fixedTimes,
+                actualTimes:      actualTimes,
+                todayStartTimes:  start,
+                todayActualTimes: actual
+            };
+        },
         /**
          * 勤怠状況集計テーブルのカラム名を取得する
          */

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -562,4 +562,33 @@
             KTR.error(message);
         }
     };
+    /**
+     * 勤務時間の詳細を取得
+     */
+    KTR.workInfo = {
+        /**
+         * 勤怠状況集計テーブルのカラム名を取得する
+         */
+        workTableColumns (html, selector) {
+            let colPos, part, columnTags;
+            const columns = {};
+            if ((colPos = html.search('<td align="center" nowrap="nowrap" class="txt_10">' + selector)) !== -1) {
+                part = html.substring(colPos);
+                columnTags = part.substr(0, part.search(/<\/tr>/)).split(/<\/td>/);
+            }
+            if (columnTags) {
+                columnTags.forEach((columnTag, index) => {
+                    let column = columnTag.replace(/<td align="center" nowrap="nowrap" class="txt_10">/g, '')
+                        .replace(/\s+/g, '')
+                        .replace(/<br\/>/g, '')
+                        .replace(/<b>/g, '')
+                        .replace(/<\/b>/g, '');
+                    if (column !== '') { columns[column] = index + 1; }
+                });
+            } else {
+                KTR.error('項目特定エラー：Issueに連絡ください。');
+            }
+            return columns;
+        }
+    };
 })(this);

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -571,8 +571,8 @@
             const doc     = parser.parseFromString(html, 'text/html');
             const table   = doc.querySelector(/* Working info summary table = */ 'table#total_list0 tr:nth-child(2)');
 
-            const summaryCols  = KTR.workInfo.workTableColumns(html, '<b>所定労働<br/>日数</b>');
-            const calendarCols = KTR.workInfo.workTableColumns(html, '<b>日</b>');
+            const summaryCols  = KTR.workInfo.workTableColumns(html, 'summary');
+            const calendarCols = KTR.workInfo.workTableColumns(html, 'calendar');
 
             // 日数
             const fixedDay = Number(table.querySelector(`td:nth-child(${summaryCols['所定労働日数']})`).textContent);
@@ -604,8 +604,9 @@
         /**
          * 勤怠状況集計テーブルのカラム名を取得する
          */
-        workTableColumns (html, selector) {
+        workTableColumns (html, type) {
             let colPos, part, columnTags;
+            let selector = (type === 'summary') ? '<b>所定労働<br/>日数</b>' : '<b>日</b>';
             const columns = {};
             if ((colPos = html.search('<td align="center" nowrap="nowrap" class="txt_10">' + selector)) !== -1) {
                 part = html.substring(colPos);

--- a/js/options.js
+++ b/js/options.js
@@ -22,6 +22,24 @@ function restore() {
     $('#start-alarm-end').val(alarms.startAlarmEnd);
     $('#leave-alarm-begin').val(alarms.leaveAlarmBegin);
     $('#leave-alarm-end').val(alarms.leaveAlarmEnd);
+
+    /**
+     * ログイン後
+     */
+    if (KTR.credential.valid()) {
+        KTR.service._request(
+            {method: 'GET'},
+            '?module=timesheet&action=browse',
+            (html) => {
+                const summaryCols = KTR.workInfo.workTableColumns(html, 'summary');
+                const dayCols     = Object.keys(summaryCols).filter( (key) => { return key.match('日'); });
+                dayCols.forEach((val) => {
+                    $('#holiday-check').append(`<div><label><input type="checkbox">${val}</label></div>`);
+                });
+                document.querySelector('#after-logged-in').style.display = 'block';
+            }
+        );
+    }
 }
 
 // 設定を保存する

--- a/js/options.js
+++ b/js/options.js
@@ -34,7 +34,7 @@ function restore() {
                 const summaryCols = KTR.workInfo.workTableColumns(html, 'summary');
                 const dayCols     = Object.keys(summaryCols).filter( (key) => { return key.match('日'); });
                 dayCols.forEach((val) => {
-                    $('#holiday-check').append(`<div><label><input type="checkbox">${val}</label></div>`);
+                    $('#holiday-check').append(`<div><label><input type="checkbox" value="${val}">${val}</label></div>`);
                 });
                 document.querySelector('#after-logged-in').style.display = 'block';
             }

--- a/js/options.js
+++ b/js/options.js
@@ -34,7 +34,7 @@ function restore() {
                 const summaryCols = KTR.workInfo.workTableColumns(html, 'summary');
                 const dayCols     = Object.keys(summaryCols).filter( (key) => { return key.match('日'); });
                 dayCols.forEach((val) => {
-                    $('#holiday-check').append(`<div><label><input type="checkbox" value="${val}">${val}</label></div>`);
+                    $('#holiday-check').append(`<div><label><input type="checkbox" name="holidays[]" value="${val}">${val}</label></div>`);
                 });
                 document.querySelector('#after-logged-in').style.display = 'block';
             }

--- a/js/popup.js
+++ b/js/popup.js
@@ -44,7 +44,8 @@ function init() {
             {method: 'GET'},
             '?module=timesheet&action=browse',
             (html) => {
-                console.log(workInfoTableColumns(html));
+                console.log(workTableColumns(html, '<td align="center" nowrap="nowrap" class="txt_10">', '<b>所定労働<br/>日数</b>'));
+                console.log(workTableColumns(html, '<td align="center" nowrap="nowrap" class="txt_10">', '<b>日</b>'));
             }
         );
     }
@@ -190,19 +191,19 @@ function openKTR(param) {
 }
 
 /**
- * 勤怠状況テーブルのカラム名を取得する
+ * 勤怠状況集計テーブルのカラム名を取得する
  */
-function workInfoTableColumns (html) {
+function workTableColumns (html, tag, selector) {
     let colPos, part, columnTags;
     const columns = [];
-    if ((colPos = html.search(/<td align="center" nowrap="nowrap" class="txt_10"><b>所定労働<br\/>日数<\/b><\/td>/)) !== -1) {
+    if ((colPos = html.search(tag + selector)) !== -1) {
         part = html.substring(colPos);
         columnTags = part.substr(0, part.search(/<\/tr>/)).split(/<\/td>/);
     }
     if (columnTags) {
         status.menus = [];
         columnTags.forEach((columnTag) => {
-            let column = columnTag.replace(/<td align="center" nowrap="nowrap" class="txt_10">/g, '')
+            let column = columnTag.replace(tag, '')
                 .replace(/\s+/g, '')
                 .replace(/<br\/>/g, '')
                 .replace(/<b>/g, '')

--- a/js/popup.js
+++ b/js/popup.js
@@ -39,6 +39,14 @@ function init() {
      */
     if (KTR.credential.valid()) {
         document.querySelector('#time-table').style.display = 'block';
+        // TODO: @tosite0345 リファクタリング
+        KTR.service._request(
+            {method: 'GET'},
+            '?module=timesheet&action=browse',
+            (html) => {
+                console.log(html);
+            }
+        );
     }
 }
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -44,8 +44,7 @@ function init() {
             {method: 'GET'},
             '?module=timesheet&action=browse',
             (html) => {
-                console.log(KTR.workInfo.workTableColumns(html, '<b>所定労働<br/>日数</b>'));
-                console.log(KTR.workInfo.workTableColumns(html, '<b>日</b>'));
+                console.log(KTR.workInfo.fetchWorkingInfoFromHtml(html));
             }
         );
     }

--- a/js/popup.js
+++ b/js/popup.js
@@ -44,8 +44,8 @@ function init() {
             {method: 'GET'},
             '?module=timesheet&action=browse',
             (html) => {
-                console.log(workTableColumns(html, '<b>所定労働<br/>日数</b>'));
-                console.log(workTableColumns(html, '<b>日</b>'));
+                console.log(KTR.workInfo.workTableColumns(html, '<b>所定労働<br/>日数</b>'));
+                console.log(KTR.workInfo.workTableColumns(html, '<b>日</b>'));
             }
         );
     }
@@ -188,29 +188,4 @@ function openKTR(param) {
     };
     KTR.error = _open;
     KTR.status.update(_open, true);
-}
-
-/**
- * 勤怠状況集計テーブルのカラム名を取得する
- */
-function workTableColumns (html, selector) {
-    let colPos, part, columnTags;
-    const columns = {};
-    if ((colPos = html.search('<td align="center" nowrap="nowrap" class="txt_10">' + selector)) !== -1) {
-        part = html.substring(colPos);
-        columnTags = part.substr(0, part.search(/<\/tr>/)).split(/<\/td>/);
-    }
-    if (columnTags) {
-        columnTags.forEach((columnTag, index) => {
-            let column = columnTag.replace(/<td align="center" nowrap="nowrap" class="txt_10">/g, '')
-                .replace(/\s+/g, '')
-                .replace(/<br\/>/g, '')
-                .replace(/<b>/g, '')
-                .replace(/<\/b>/g, '');
-            if (column !== '') { columns[column] = index; }
-        });
-    } else {
-        KTR.error('項目特定エラー：Issueに連絡ください。');
-    }
-    return columns;
 }

--- a/js/popup.js
+++ b/js/popup.js
@@ -44,8 +44,8 @@ function init() {
             {method: 'GET'},
             '?module=timesheet&action=browse',
             (html) => {
-                console.log(workTableColumns(html, '<td align="center" nowrap="nowrap" class="txt_10">', '<b>所定労働<br/>日数</b>'));
-                console.log(workTableColumns(html, '<td align="center" nowrap="nowrap" class="txt_10">', '<b>日</b>'));
+                console.log(workTableColumns(html, '<b>所定労働<br/>日数</b>'));
+                console.log(workTableColumns(html, '<b>日</b>'));
             }
         );
     }
@@ -193,17 +193,17 @@ function openKTR(param) {
 /**
  * 勤怠状況集計テーブルのカラム名を取得する
  */
-function workTableColumns (html, tag, selector) {
+function workTableColumns (html, selector) {
     let colPos, part, columnTags;
     const columns = [];
-    if ((colPos = html.search(tag + selector)) !== -1) {
+    if ((colPos = html.search('<td align="center" nowrap="nowrap" class="txt_10">' + selector)) !== -1) {
         part = html.substring(colPos);
         columnTags = part.substr(0, part.search(/<\/tr>/)).split(/<\/td>/);
     }
     if (columnTags) {
         status.menus = [];
         columnTags.forEach((columnTag) => {
-            let column = columnTag.replace(tag, '')
+            let column = columnTag.replace(/<td align="center" nowrap="nowrap" class="txt_10">/g, '')
                 .replace(/\s+/g, '')
                 .replace(/<br\/>/g, '')
                 .replace(/<b>/g, '')

--- a/js/popup.js
+++ b/js/popup.js
@@ -209,6 +209,8 @@ function workInfoTableColumns (html) {
                 .replace(/<\/b>/g, '');
             if (column !== '') { columns.push(column); }
         });
+    } else {
+        KTR.error('項目特定エラー：Issueに連絡ください。');
     }
     return columns;
 }

--- a/js/popup.js
+++ b/js/popup.js
@@ -195,20 +195,19 @@ function openKTR(param) {
  */
 function workTableColumns (html, selector) {
     let colPos, part, columnTags;
-    const columns = [];
+    const columns = {};
     if ((colPos = html.search('<td align="center" nowrap="nowrap" class="txt_10">' + selector)) !== -1) {
         part = html.substring(colPos);
         columnTags = part.substr(0, part.search(/<\/tr>/)).split(/<\/td>/);
     }
     if (columnTags) {
-        status.menus = [];
-        columnTags.forEach((columnTag) => {
+        columnTags.forEach((columnTag, index) => {
             let column = columnTag.replace(/<td align="center" nowrap="nowrap" class="txt_10">/g, '')
                 .replace(/\s+/g, '')
                 .replace(/<br\/>/g, '')
                 .replace(/<b>/g, '')
                 .replace(/<\/b>/g, '');
-            if (column !== '') { columns.push(column); }
+            if (column !== '') { columns[column] = index; }
         });
     } else {
         KTR.error('項目特定エラー：Issueに連絡ください。');

--- a/js/popup.js
+++ b/js/popup.js
@@ -33,6 +33,13 @@ function init() {
             $service.text('新しいお知らせ').addClass('attention');
         }
     });
+
+    /**
+     * ログインしていたら勤務テーブルを表示する
+     */
+    if (KTR.credential.valid()) {
+        document.querySelector('#time-table').style.display = 'block';
+    }
 }
 
 /**

--- a/js/popup.js
+++ b/js/popup.js
@@ -44,7 +44,7 @@ function init() {
             {method: 'GET'},
             '?module=timesheet&action=browse',
             (html) => {
-                console.log(html);
+                console.log(workInfoTableColumns(html));
             }
         );
     }
@@ -187,4 +187,28 @@ function openKTR(param) {
     };
     KTR.error = _open;
     KTR.status.update(_open, true);
+}
+
+/**
+ * 勤怠状況テーブルのカラム名を取得する
+ */
+function workInfoTableColumns (html) {
+    let colPos, part, columnTags;
+    const columns = [];
+    if ((colPos = html.search(/<td align="center" nowrap="nowrap" class="txt_10"><b>所定労働<br\/>日数<\/b><\/td>/)) !== -1) {
+        part = html.substring(colPos);
+        columnTags = part.substr(0, part.search(/<\/tr>/)).split(/<\/td>/);
+    }
+    if (columnTags) {
+        status.menus = [];
+        columnTags.forEach((columnTag) => {
+            let column = columnTag.replace(/<td align="center" nowrap="nowrap" class="txt_10">/g, '')
+                .replace(/\s+/g, '')
+                .replace(/<br\/>/g, '')
+                .replace(/<b>/g, '')
+                .replace(/<\/b>/g, '');
+            if (column !== '') { columns.push(column); }
+        });
+    }
+    return columns;
 }


### PR DESCRIPTION
## 何を解決するのか😊

先に https://github.com/irok/KinnosukeTimeRecorder/pull/11 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/12 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/13 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/14 をマージします。

このPRでオプションページを用意します。

### 作業範囲
- ログインしていない場合設定画面を隠す
- テキストに「日」が含まれるものをチェックボックス表示する
- その他使いそうな設定を追加

### TODOリスト
**１．設定が煩雑な点を何とかする**
- [x] 共通の項目を列名から自動的に特定する
- [x] 特定できない場合に案内を表示する
- [x] 出勤簿のテーブルの休暇見出し行を取得する
- [ ] チェックボックスを置いて選択できるようにする

**２．認証情報がない状態を考慮する**
- [x] 未ログイン時、出勤状況テーブルを非表示にする
- [x] 未ログイン時、出勤状況テーブル設定情報を非表示にする

**３．各メニューと出勤状況の位置を変更する**
- [x] テーブルをメニューの下部に持っていく

### スクリーンショット
![image](https://user-images.githubusercontent.com/24952964/53418287-cc244300-3a1a-11e9-9839-05a20b98d6f2.png)
