### PR TITLE
勤怠状況機能のON/OFFを設定できるようにします

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -115,8 +115,8 @@ button {
   <div id="after-logged-in">
     <h2>勤務状況</h2>
     <div class="settings">
-      <label><input type="radio" name="table-enable" value="enale">勤務状況機能を利用する</label>
-      <label><input type="radio" name="table-enable" value="disable">勤務状況機能を利用しない</label>
+      <label><input type="radio" name="enable-work-info" value="enale">勤務状況機能を利用する</label>
+      <label><input type="radio" name="enable-work-info" value="disable">勤務状況機能を利用しない</label>
     </div>
     <h2>勤務形態</h2>
     <div class="settings">

--- a/html/options.html
+++ b/html/options.html
@@ -70,7 +70,7 @@ button {
   font: inherit;
   text-shadow: 0 1px 0 rgb(240, 240, 240);
 }
-#after-logged-in { display: none; }
+#after-logged-in, #enable-work-info-settings { display: none; }
 </style>
 <script src="/vendor/jquery.js"></script>
 <script src="/vendor/crypto-js.js"></script>
@@ -115,17 +115,19 @@ button {
   <div id="after-logged-in">
     <h2>勤務状況</h2>
     <div class="settings">
-      <label><input type="radio" name="enable-work-info" value="enale">勤務状況機能を利用する</label>
+      <label><input type="radio" name="enable-work-info" value="enable">勤務状況機能を利用する</label>
       <label><input type="radio" name="enable-work-info" value="disable">勤務状況機能を利用しない</label>
     </div>
-    <h2>勤務形態</h2>
-    <div class="settings">
-      <label><input type="radio" name="work-type" value="fix">固定時間制</label>
-      <label><input type="radio" name="work-type" value="flex">フレックス制</label>
+    <div id="enable-work-info-settings">
+      <h2>勤務形態</h2>
+      <div class="settings">
+        <label><input type="radio" name="work-type" value="fix">固定時間制</label>
+        <label><input type="radio" name="work-type" value="flex">フレックス制</label>
+      </div>
+      <h2>休暇情報</h2>
+      <div id="holiday-check" class="settings"></div>
+      <p>休日に該当するチェックボックスにチェックを入れてください。</p>
     </div>
-    <h2>休暇情報</h2>
-    <div id="holiday-check" class="settings"></div>
-    <p>休日に該当するチェックボックスにチェックを入れてください。</p>
   </div>
   <button id="saveBtn">保存する</button>
 </section>

--- a/html/popup.html
+++ b/html/popup.html
@@ -90,7 +90,7 @@ button.confirm:last-child {
 }
 #time-table { width: 100%; display: none; }
 #time-table th, #time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
-
+#time-table .is-flex { display: none; }
 </style>
 <script src="/vendor/jquery.js"></script>
 <script src="/vendor/crypto-js.js"></script>
@@ -132,14 +132,14 @@ button.confirm:last-child {
       <td id="need-day">-</td>
       <td id="need-time">--:--</td>
     </tr>
-    <tr>
+    <tr class="is-flex">
       <th colspan="2">予定過不足時間 <small>※</small></th>
       <td id="expect-time">--:--</td>
     </tr>
-    <tr><td colspan="3"><small>※ 所定時間働いた場合の過不足</small></td></tr>
-    <tr>
+    <tr class="is-flex"><td colspan="3"><small>※ 所定時間働いた場合の過不足</small></td></tr>
+    <tr class="is-flex">
       <th colspan="2">一日あたり必要時間</th>
-      <td id="time-per-day">--:--</td>
+      <td id="expect-perday-time">--:--</td>
     </tr>
     <tr>
       <th colspan="2">今日の勤務時間 <small>※</small></th>

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -278,7 +278,7 @@
      */
     KTR.enableWorkInfo = {
         get() {
-            let enableWorkInfo = localStorage.ShowWorkInfo;
+            let enableWorkInfo = localStorage.EnableWorkInfo;
             if (typeof enableWorkInfo == 'undefined') { enableWorkInfo = localStorage.EnableWorkInfo = 'disable'; }
             return enableWorkInfo;
         },

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -691,6 +691,22 @@
             };
         },
         /**
+         * 時間をテーブルにセットする
+         */
+        setTimesToTable (days, times) {
+            $('#fixed-day'         ).text(`${days.fixed}日`);
+            $('#actual-day'        ).text(`${days.actual}日`);
+            $('#need-day'          ).text(`${days.need}日`);
+            $('#holiday'           ).text(`${days.holiday}日`);
+            $('#fixed-time'        ).text(`${times.fixed.display}`);
+            $('#actual-time'       ).text(`${times.actual.display}`);
+            $('#need-time'         ).text(`${times.need.display}`);
+            $('#expect-time'       ).text(`${times.expect.sign}${times.expect.display}`);
+            $('#expect-perday-time').text(`${times.expectPerday.display}`);
+            $('#today-time'        ).text(`${times.today.display}`);
+
+        },
+        /**
          * 時間の配列またはタイムスタンプを整形する
          * example:
          * KTR.workInfo.toTime([12, 20])

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -273,7 +273,17 @@
         }
     };
 
-    // PENDING: @tosite0345 勤務状況非表示機能
+    /**
+     * 勤務状況表示
+     */
+    KTR.enableWorkInfo = {
+        get() {
+            let enableWorkInfo = localStorage.ShowWorkInfo;
+            if (typeof enableWorkInfo == 'undefined') { enableWorkInfo = localStorage.EnableWorkInfo = 'disable'; }
+            return enableWorkInfo;
+        },
+        update(enableWorkInfo) { localStorage.EnableWorkInfo = enableWorkInfo; }
+    };
 
     /**
      * 勤務形態

--- a/js/options.js
+++ b/js/options.js
@@ -28,6 +28,7 @@ function restore() {
      */
     if (KTR.credential.valid()) {
         $(`[name="work-type"][value="${KTR.worktype.get()}"]`).prop('checked', true);
+        $(`[name="enable-work-info"][value="${KTR.enableWorkInfo.get()}"]`).prop('checked', true);
         const holidays = KTR.holidays.get();
         KTR.service._request(
             {method: 'GET'},
@@ -40,7 +41,6 @@ function restore() {
                     $('#holiday-check').append(`<div><label><input type="checkbox" name="holidays[]" value="${val}" ${checked}>${val}</label></div>`);
                 });
                 document.querySelector('#after-logged-in').style.display = 'block';
-
             }
         );
     }
@@ -68,6 +68,7 @@ function save() {
     if (KTR.credential.valid()) {
         const holidays = [];
         KTR.worktype.update($(`[name="work-type"]:checked`).val());
+        KTR.enableWorkInfo.update($(`[name="enable-work-info"]:checked`).val());
         $(`[name="holidays[]"]:checked`).each((index, elm) => { holidays.push($(elm).val()); })
         KTR.holidays.update(holidays);
     }

--- a/js/options.js
+++ b/js/options.js
@@ -1,7 +1,16 @@
 $(function() {
     restore();
     $('#saveBtn').click(save);
+    $(`[name="enable-work-info"]`).change(hoge);
 });
+
+function hoge(){
+    if($(`[name="enable-work-info"]:checked`).val() == 'enable') {
+        $('#enable-work-info-settings').fadeIn();
+    } else {
+        $('#enable-work-info-settings').fadeOut();
+    }
+}
 
 // 設定を読み込んでフォームにセットする
 function restore() {

--- a/js/popup.js
+++ b/js/popup.js
@@ -47,7 +47,6 @@ function init() {
                 const workInfo  = KTR.workInfo.fetchWorkingInfoFromHtml(html);
                 const workTimes = KTR.workInfo.calcWorkTimes(workInfo);
                 KTR.workInfo.setTimesToTable(workTimes.days, workTimes.times);
-                if (KTR.worktype.get() === 'flex') { $('.is-flex').show(); }
             }
         );
     }

--- a/js/popup.js
+++ b/js/popup.js
@@ -46,7 +46,7 @@ function init() {
             (html) => {
                 const workInfo  = KTR.workInfo.fetchWorkingInfoFromHtml(html);
                 const workTimes = KTR.workInfo.calcWorkTimes(workInfo);
-                console.log(workTimes);
+                KTR.workInfo.setTimesToTable(workTimes.days, workTimes.times);
             }
         );
     }

--- a/js/popup.js
+++ b/js/popup.js
@@ -35,11 +35,10 @@ function init() {
     });
 
     /**
-     * ログインしていたら勤務テーブルを表示する
+     * ログインしており、かつ勤務状況機能を利用する場合に勤務テーブルを表示する
      */
-    if (KTR.credential.valid()) {
+    if (KTR.credential.valid() && KTR.enableWorkInfo.get() === 'enable') {
         document.querySelector('#time-table').style.display = 'block';
-        // TODO: @tosite0345 リファクタリング
         KTR.service._request(
             {method: 'GET'},
             '?module=timesheet&action=browse',

--- a/js/popup.js
+++ b/js/popup.js
@@ -47,6 +47,7 @@ function init() {
                 const workInfo  = KTR.workInfo.fetchWorkingInfoFromHtml(html);
                 const workTimes = KTR.workInfo.calcWorkTimes(workInfo);
                 KTR.workInfo.setTimesToTable(workTimes.days, workTimes.times);
+                if (KTR.worktype.get() === 'flex') { $('.is-flex').show(); }
             }
         );
     }


### PR DESCRIPTION
## 何を解決するのか😊

先に https://github.com/irok/KinnosukeTimeRecorder/pull/11 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/12 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/13 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/14 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/15 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/16 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/17 ・ https://github.com/irok/KinnosukeTimeRecorder/pull/18 をマージします。

勤怠状況機能のON/OFFを設定できるようにします。

### 作業範囲
- 勤怠状況機能をストレージに保存
- オプション画面を勤怠状況機能の状態によって変更
- 勤怠状況機能の状態によって表示・非表示

### TODOリスト
**１．設定が煩雑な点を何とかする**
- [x] 共通の項目を列名から自動的に特定する
- [x] 特定できない場合に案内を表示する
- [x] 出勤簿のテーブルの休暇見出し行を取得する
- [x] チェックボックスを置いて選択できるようにする
- [x] 勤怠状況機能のON/OFFを実装する

**２．認証情報がない状態を考慮する**
- [x] 未ログイン時、出勤状況テーブルを非表示にする
- [x] 未ログイン時、出勤状況テーブル設定情報を非表示にする

**３．各メニューと出勤状況の位置を変更する**
- [x] テーブルをメニューの下部に持っていく

### スクリーンショット

|項目|勤怠状況機能OFF|勤怠状況機能ON|
| --- | --- | --- |
|設定画面| ![image](https://user-images.githubusercontent.com/24952964/53507011-7757f980-3afa-11e9-802f-2a5bb07854fd.png) | ![image](https://user-images.githubusercontent.com/24952964/53507049-850d7f00-3afa-11e9-908b-cacc0f65b37e.png) |
| ポップアップ | ![image](https://user-images.githubusercontent.com/24952964/53507154-aec6a600-3afa-11e9-9c35-6aebf273cbf0.png) | ![image](https://user-images.githubusercontent.com/24952964/53507178-bb4afe80-3afa-11e9-9373-d1dba51bb64d.png) |