### PR TITLE
ポップアップ画面に勤怠状況を表示します

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -90,7 +90,7 @@ button.confirm:last-child {
 }
 #time-table { width: 100%; display: none; }
 #time-table th, #time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
-
+#time-table .is-flex { display: none; }
 </style>
 <script src="/vendor/jquery.js"></script>
 <script src="/vendor/crypto-js.js"></script>
@@ -132,18 +132,18 @@ button.confirm:last-child {
       <td id="need-day">-</td>
       <td id="need-time">--:--</td>
     </tr>
-    <tr>
+    <tr class="is-flex">
       <th colspan="2">予定過不足時間 <small>※</small></th>
       <td id="expect-time">--:--</td>
     </tr>
-    <tr><td colspan="3"><small>※ 所定時間働いた場合の過不足</small></td></tr>
-    <tr>
+    <tr class="is-flex"><td colspan="3"><small>※ 所定時間働いた場合の過不足</small></td></tr>
+    <tr class="is-flex">
       <th colspan="2">一日あたり必要時間</th>
       <td id="time-per-day">--:--</td>
     </tr>
     <tr>
       <th colspan="2">今日の勤務時間 <small>※</small></th>
-      <td id="today-time">--:--</td>
+      <td id="expect-perday-time">--:--</td>
     </tr>
     <tr><td colspan="3"><small>※ 休憩時間を含む</small></td></tr>
   </table>

--- a/html/popup.html
+++ b/html/popup.html
@@ -136,7 +136,7 @@ button.confirm:last-child {
       <th colspan="2">予定過不足時間 <small>※</small></th>
       <td id="expect-time">--:--</td>
     </tr>
-    <tr class="is-flex"><td colspan="3"><small>※ 所定時間働いた場合の過不足</small></td></tr>
+    <tr class="is-flex"><td colspan="3"><small>※ 一日<span id="perday-time">-:--</span>働いた場合の過不足</small></td></tr>
     <tr class="is-flex">
       <th colspan="2">一日あたり必要時間</th>
       <td id="time-per-day">--:--</td>

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -691,6 +691,21 @@
             };
         },
         /**
+         * 時間をテーブルにセットする
+         */
+        setTimesToTable (days, times) {
+            $('#fixed-day'         ).text(`${days.fixed}日`);
+            $('#actual-day'        ).text(`${days.actual}日`);
+            $('#need-day'          ).text(`${days.need}日`);
+            $('#holiday'           ).text(`${days.holiday}日`);
+            $('#fixed-time'        ).text(`${times.fixed.display}`);
+            $('#actual-time'       ).text(`${times.actual.display}`);
+            $('#need-time'         ).text(`${times.need.display}`);
+            $('#expect-time'       ).text(`${times.expect.sign}${times.expect.display}`);
+            $('#expect-perday-time').text(`${times.expectPerday.display}`);
+            $('#today-time'        ).text(`${times.today.display}`);
+        },
+        /**
          * 時間の配列またはタイムスタンプを整形する
          * example:
          * KTR.workInfo.toTime([12, 20])

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -667,7 +667,7 @@
                 expectTimes       = KTR.workInfo.toTime(needTimes.time === 0 ? 0 : (needDay * perdayTimes.time) - needTimes.time);
                 expectPerdayTimes = KTR.workInfo.toTime(Math.floor(needTimes.time / needDay));
             } else {
-                expectTimes       = KTR.workInfo.toTime(perdayTimes.time - needTimes.time);
+                expectTimes       = KTR.workInfo.toTime(needTimes.time === 0 ? 0 : perdayTimes.time - needTimes.time);
                 expectPerdayTimes = KTR.workInfo.toTime(needTimes.time );
             }
             expectTimes.sign = (expectTimes.time < 0) ? "-" : "+";

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -701,6 +701,7 @@
             $('#fixed-time'        ).text(`${times.fixed.display}`);
             $('#actual-time'       ).text(`${times.actual.display}`);
             $('#need-time'         ).text(`${times.need.display}`);
+            $('#perday-time'       ).text(`${times.perday.display}`);
             $('#expect-time'       ).text(`${times.expect.sign}${times.expect.display}`);
             $('#expect-perday-time').text(`${times.expectPerday.display}`);
             $('#today-time'        ).text(`${times.today.display}`);

--- a/js/popup.js
+++ b/js/popup.js
@@ -46,7 +46,8 @@ function init() {
             (html) => {
                 const workInfo  = KTR.workInfo.fetchWorkingInfoFromHtml(html);
                 const workTimes = KTR.workInfo.calcWorkTimes(workInfo);
-                console.log(workTimes);
+                KTR.workInfo.setTimesToTable(workTimes.days, workTimes.times);
+                if (KTR.worktype.get() === 'flex') { $('.is-flex').show(); }
             }
         );
     }


### PR DESCRIPTION
## 何を解決するのか😊
https://github.com/irok/KinnosukeTimeRecorder/pull/18 がこんがらがってきたので焼き増ししました。

計算した値をポップアップ画面に表示します。
フレックス制の場合のみ表示する項目の表示・非表示を切り替えます。

### 作業範囲
- 勤怠状況の表示
- オプションの値によって表示する項目を変更

### TODOリスト
**１．設定が煩雑な点を何とかする**
- [x] 共通の項目を列名から自動的に特定する
- [x] 特定できない場合に案内を表示する
- [x] 出勤簿のテーブルの休暇見出し行を取得する
- [x] チェックボックスを置いて選択できるようにする

**２．認証情報がない状態を考慮する**
- [x] 未ログイン時、出勤状況テーブルを非表示にする
- [x] 未ログイン時、出勤状況テーブル設定情報を非表示にする

**３．各メニューと出勤状況の位置を変更する**
- [x] テーブルをメニューの下部に持っていく

### スクリーンショット

|固定時間制|フレックス制|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/24952964/53506557-89856800-3af9-11e9-9af8-d4412121e0a5.png) | ![image](https://user-images.githubusercontent.com/24952964/53569265-294cff80-3ba7-11e9-8365-74b4f19d3ead.png) |
