### PR TITLE
勤怠時間（分）が一桁の場合に表示が崩れる問題を修正します

### DIFF
--- a/js/ktr.js
+++ b/js/ktr.js
@@ -732,8 +732,9 @@
         toTime(times){
             const time = (times.length != 2) ? times : times[0] * 60 + times[1];
             const h    = (time > 0) ? Math.floor(time / 60) : Math.ceil(time / 60);
+            const m    = Math.abs(time % 60);
             const hour = `${Math.abs(h)}`;
-            const min  = (`00${time % 60}`).slice(-2);
+            const min  = (`00${m}`).slice(-2);
             return {
                 time:    time,
                 hour:    hour,

--- a/js/ktr.js
+++ b/js/ktr.js
@@ -682,7 +682,7 @@
             } else {
                 expectPerdayTimes = KTR.workInfo.toTime(needTimes.time );
             }
-            expectTimes.sign = (expectTimes.time < 0) ? "-" : "+";
+            expectTimes.sign = (expectTimes.time < 0) ? "超過" : "不足";
 
             return {
                 days:  {
@@ -714,7 +714,7 @@
             $('#actual-time'       ).text(`${times.actual.display}`);
             $('#need-time'         ).text(`${times.need.display}`);
             $('#perday-time'       ).text(`${times.perday.display}`);
-            $('#expect-time'       ).text(`${times.expect.sign}${times.expect.display}`);
+            $('#expect-time'       ).text(`${times.expect.display} ${times.expect.sign}`);
             $('#time-per-day'      ).text(`${times.expectPerday.display}`);
             $('#today-time'        ).text(`${times.today.display}`);
         },


### PR DESCRIPTION
## 何を解決するのか
https://github.com/irok/KinnosukeTimeRecorder/issues/27 こちらのバグを解消します。
`-12:-4` の表記を `-12:04` となるようにします。

合わせて `- +` の表記が分かりにくいとの声があったため、 `超過 不足` で表示するようにしました。

|不足時|超過時|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/24952964/55637435-02b26200-5800-11e9-9536-2f063a552fbf.png) | ![image](https://user-images.githubusercontent.com/24952964/55637423-f9c19080-57ff-11e9-9e04-2d331e1ea604.png) |
